### PR TITLE
Initial Import CG report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+# This workflow validates the document for markup and examples.
+name: CI
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    name: Build and Validate Spec
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Validate via ReSpec
+    # See https://github.com/w3c/spec-prod/blob/main/docs/examples.md
+    - name: ReSpec Checker
+      uses: w3c/spec-prod@v2
+      with:
+        TOOLCHAIN: respec
+        SOURCE: spec/index.html
+        VALIDATE_LINKS: false
+        VALIDATE_MARKUP: true

--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,0 +1,4 @@
+{
+    "src_file": "spec/index.html",
+    "type": "respec"
+}

--- a/spec/index.html
+++ b/spec/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta content="text/html; charset=utf-8" http-equiv="content-type" />
 <meta content="width=device-width,initial-scale=1" name="viewport" />
@@ -9,71 +9,110 @@
 <script class="remove">
 //<![CDATA[
   var respecConfig = {
-      doJsonLd: true,
-      // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
-      specStatus:           "CG-DRAFT",
-      //publishDate:          "2010-04-29",
-      copyrightStart:       "2010",
-
-      // the specification's short name, as in http://www.w3.org/TR/short-name/
-      shortName:            "rdf-dataset-canonicalization",
-      subtitle:             "A Standard RDF Dataset Canonicalization Algorithm",
-      // if you wish the publication date to be other than today, set this
-      // publishDate:  "2009-08-06",
-
-      // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
-      // and its maturity status
-      //previousPublishDate:  "2011-08-17",
-      //previousMaturity:     "ED",
-      //previousDiffURI:      "https://json-ld.org/spec/ED/20110817/index.html",
-      //diffTool:             "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
-
-      // if there a publicly available Editor's Draft, this is the link
-      edDraftURI:           "https://json-ld.github.io/rdf-dataset-canonicalization/spec/",
-
-      github: {
-        repoURL: "https://github.com/json-ld/rdf-dataset-canonicalization/",
-          branch: "main"
+    localBiblio: {
+      "CCG-RDC-FINAL": {
+        id: "CCG-RDC-FINAL",
+        title: "RDF Dataset Canonicalization",
+        authors: ["Dave Longley"],
+        editors: [
+          "Dave Longley",
+          "Manu Sporny"
+        ],
+        date: "2022-10-09",
+        href: "https://www.w3.org/community/reports/credentials/CG-FINAL-rdf-dataset-canonicalization-20221009/",
+        status: "CG-FINAL",
+        publisher: "W3C"
       },
+      "DesignIssues-Diff": {
+        id: "DesignIssues-Diff",
+        title: "Delta: an ontology for the distribution of differences between RDF graphs",
+        authors: ["Tim Berners-Leee"],
+        date: "2015-09-25",
+        href: "https://www.w3.org/DesignIssues/Diff",
+        status: "unofficial",
+        publisher: "W3C"
+      },
+      "eswc2014Kasten": {
+        id: "eswc2014Kasten",
+        title: "A Framework for Iterative Signing of Graph Data on the Web",
+        authors: ["Andreas Kasten", "Ansgar Scherp", "Peter Schauß "],
+        date: "2014",
+        href: "https://doi.org/10.1007/978-3-319-07443-6_11",
+        status: "unofficial",
+        publisher: "ISWC 2014"
+      },
+      "Hogan-Canonical-RDF": {
+        id: "Hogan-Canonical-RDF",
+        title: "Canonical Forms for Isomorphic and Equivalent RDF Graphs: Algorithms for Leaning and Labelling Blank Nodes",
+        authors: ["Aiden Hogan"],
+        date: "2017-07-17",
+        href: "https://aidanhogan.com/docs/rdf-canonicalisation.pdf",
+        status: "unofficial",
+        publisher: "ACM Transactions on the Web"
+      },
+      "HPL-2003-142": {
+        id: "HPL-2003-142",
+        title: "Signing RDF Graphs",
+        authors: ["Jeremy J. Carroll"],
+        date: "2003-07-23",
+        href: "https://www.hpl.hp.com/techreports/2003/HPL-2003-142.pdf",
+        publisher: "HP Laboratories Bristol",
+        status: "unofficial"
+      }
+    },
+    doJsonLd: true,
+    specStatus:           "ED",
+    //publishDate:          "2010-04-29",
+    copyrightStart:       "2010",
 
-      // if this is a LCWD, uncomment and set the end of its review period
-      // lcEnd: "2009-08-05",
+    // the specification's short name, as in http://www.w3.org/TR/short-name/
+    shortName:            "rdf-dataset-canonicalization",
+    subtitle:             "A Standard RDF Dataset Canonicalization Algorithm",
+    // if you wish the publication date to be other than today, set this
+    // publishDate:  "2009-08-06",
 
-      // if you want to have extra CSS, append them to this list
-      // it is recommended that the respec.css stylesheet be kept
-      // extraCSS: [],
+    // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+    // and its maturity status
+    //previousPublishDate:  "2022-10-09",
+    //previousMaturity:     "CG-FINAL",
+    //previousDiffURI:      "",
 
-      // editors, add as many as you like
-      // only "name" is required
-      editors:  [
-          { name: "Dave Longley", url: "https://digitalbazaar.com/",
-            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/"},
-          { name: "Manu Sporny", url: "http://manu.sporny.org/",
-            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/" }
-      ],
+    github: "https://github.com/w3c/rch-rdc/",
 
-      // authors, add as many as you like.
-      // This is optional, uncomment if you have authors as well as editors.
-      // only "name" is required. Same format as editors.
-      authors:  [
-          { name: "Dave Longley", url: "https://digitalbazaar.com/",
-            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/"}
-      ],
+    // if this is a LCWD, uncomment and set the end of its review period
+    // lcEnd: "2009-08-05",
 
-      // name of the 
-      group: "credentials",
+    // if you want to have extra CSS, append them to this list
+    // it is recommended that the respec.css stylesheet be kept
+    // extraCSS: [],
 
-      // URI of the public WG page
-      wgURI: "https://www.w3.org/community/credentials/",
+    // editors, add as many as you like
+    // only "name" is required
+    editors:  [
+        { name: "Dave Longley", url: "https://digitalbazaar.com/",
+          company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/"},
+        { name: "Manu Sporny", url: "http://manu.sporny.org/",
+          company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/" }
+    ],
 
-      // name (with the @w3c.org) of the public mailing to which comments are due
-      wgPublicList: "public-credentials-wg@w3.org",
-      wgPatentURI:  "https://www.w3.org/Consortium/Patent-Policy-20200915/",
-      maxTocLevel: 2
+    // authors, add as many as you like.
+    // This is optional, uncomment if you have authors as well as editors.
+    // only "name" is required. Same format as editors.
+    authors:  [
+        { name: "Dave Longley", url: "https://digitalbazaar.com/",
+          company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/"}
+    ],
+
+    // name of the 
+    group: "rch",
+    xref: ["rdf11-concepts", "rdf11-mt"],
+
+    // name (with the @w3c.org) of the public mailing to which comments are due
+    wgPublicList: "public-rch-wg@w3.org"
   };
 //]]>
 </script>
-<style type="text/css">
+<style>
   .highlight { font-weight: bold; color: #0a3; }
   .comment { color: #999; }
   table, thead, tr, td { padding: 5px; border-width: 1px; border-spacing: 0px; border-style: solid; border-collapse: collapse; }
@@ -105,14 +144,12 @@
 </section>
 
 <section id="sotd">
-  <p>This document is a work in progress.</p>
-  <!-- <p>This document has been reviewed by W3C Members, by software
-    developers, and by other W3C groups and interested parties, and is
-    endorsed by the Director as a W3C Recommendation. It is a stable
-    document and may be used as reference material or cited from another
-    document. W3C's role in making the Recommendation is to draw attention
-    to the specification and to promote its widespread deployment. This
-    enhances the functionality and interoperability of the Web.</p> -->
+  <p>
+    A previous version
+    of this specification was published by the
+    <a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>
+    as [[CCG-RDC-FINAL]].
+  </p>
 </section>
 
 <section>
@@ -152,7 +189,6 @@
     <strong>Universal RDF Dataset Canonicalization Algorithm 2015</strong> or
     <a>URDNA2015</a>.</p>
 
-  <div class="issue" data-number="2"></div>
   <section>
     <h2>Uses of Dataset Canonicalization</h2>
     <p>There are different use cases where graph or dataset canonicalization are important:</p>
@@ -171,8 +207,20 @@
     <p>Further more, RDF semantics dictate that deserializing the same RDF document results in the creation of unique <a>blank nodes</a>, unless it can be determined that on each occasion, the <a>blank node identifiers</a> the same resource; this is due to the fact that <a>blank node identifiers</a> are an aspect of a concrete RDF syntax and are not intended to be persistent or portable. Within the abstract RDF model, blank nodes do not have identifiers (although some <a data-cite="RDF11-CONCEPTS#dfn-rdf-store">RDF store</a> implementations may use stable identifiers and choose to make them portable). See <cite><a data-cite="RDF11-CONCEPTS#section-blank-nodes">Blank Nodes</a></cite> in [[!RDF-CONCEPTS]] for more information.</p>
     <p>RDF does have a provision for allowing blank nodes to be published in an externally identifiable way through the use of <a data-cite="RDF11-CONCEPTS#dfn-skolem-iri">Skolem IRIs</a>, which allows a given RDF store to replace the use of blank nodes in a concrete syntax with IRIs, which serve to repeatably identify that blank node within that particular RDF store, however, this is not generally useful for talking about the same graph in different RDF stores, or other concrete representations. In any case, a stable <a>blank node identifier</a> defined for one RDF store, serialization is arbitrary, and typically not relatable to the context within which it is used.</p>
     <p>This specification defines an algorithm for creating stable <a>blank node identifiers</a> repeatably for different serializations possibly using individualized <a>blank node identifiers</a> of the same RDF graph (dataset) by grounding each <a>blank node</a> through the nodes to which it is connected, essentially creating <em>Skolem <a>blank node identifiers</a></em>. As a result, a graph signature can be obtained by hashing a canonical serialization of the resulting <a>normalized dataset</a>, allowing for the isomorphism and digital signing use cases. As blank node identifiers can be stable even with other changes to a graph (dataset), in some cases it is possible to compute the difference between two graphs (datasets), for example if changes are made only to ground triples, or if new blank nodes are introduced which do not create an automorphic confusion with other existing blank nodes. If any information which would change the generated blank node identifier, a resulting diff might indicate a greater set of changes than actually exists.</p>
-    <p class="ednote">TimBL has a <a href="http://www.w3.org/DesignIssues/Diff">design note</a> on problems with Diff which should be referenced.</p>
-    <p class="ednote">Jerremy Carroll has a <a href="http://www.hpl.hp.com/techreports/2003/HPL-2003-142.pdf">paper</a> on signing RDF graphs.</p>
+
+    <div class="ednote">
+      <p>Add descriptions for relevant historical discussions and prior art:</p>
+      <dl>
+        <dt>[[DesignIssues-Diff]]</dt>
+        <dd>TimBL's design note on problems with Diff.</dd>
+        <dt>[[eswc2014Kasten]]</dt>
+        <dd>A Framework for Iterative Signing of Graph Data on the Web.</dd>
+        <dt>[[Hogan-Canonical-RDF]]</dt>
+        <dd>Aiden Hogan's paper on canonicalizing RDF</dd>
+        <dt>[[HPL-2003-142]]</dt>
+        <dd>Jeremy J. Carroll's paper on signing RDF graphs.</dd>
+      </dl>
+    </div>
   </section>
 
   <section>
@@ -193,31 +241,6 @@
       <a href="https://en.wikipedia.org/wiki/Graph_theory">graph theory</a> and
       <a href="https://en.wikipedia.org/wiki/Graph_isomorphism">graph isomorphism</a>
       is also recommended.</p>
-  </section>
-
-  <section>
-    <h2>Contributing</h2>
-
-    <p>There are a number of ways that one may participate in the development
-      of this specification:</p>
-
-    <ul>
-      <li>Technical discussion typically occurs on the public mailing list:
-        <a href="http://lists.w3.org/Archives/Public/public-credentials/">public-credentials@w3.org</a></li>
-
-      <li><a href="https://opencreds.org/minutes/">Public teleconferences</a> are
-        held on Tuesdays at 1600UTC every week of each month.</li>
-
-      <li>Specification bugs and issues should be reported in the
-        <a href="https://github.com/json-ld/rdf-dataset-canonicalization/issues">issue tracker</a>.</li>
-
-      <li><a href="https://github.com/json-ld/rdf-dataset-canonicalization/tree/main/spec">Source code</a> for the
-        specification can be found on GitHub.</li>
-
-      <li>The <a href="https://webchat.freenode.net/?channels=#credentials">#credentials</a>
-        IRC channel is available for real-time discussion on
-        <a href="irc.freenode.net">irc.freenode.net.</a></li>
-    </ul>
   </section>
 </section>
 
@@ -297,7 +320,7 @@
   <p>In time, there may be more than one canonicalization algorithm and,
     therefore, for identification purposes, this algorithm is named the
     "Universal RDF Dataset Canonicalization Algorithm 2015"
-    (<abbr title="Universal RDF Dataset Canonicalization Algorithm 2015"><dfn>URDNA2015</dfn></abbr>).</p>
+    (<abbr title="Universal RDF Dataset Canonicalization Algorithm 2015"><dfn class="export">URDNA2015</dfn></abbr>).</p>
 
   <p class="ednote">This statement is overly prescriptive and does not include normative language.
     This spec should describe the theoretical basis for graph canonicalization and describe
@@ -850,7 +873,7 @@
   <p>A previous version of this algorithm has light deployment. For purposes of identification,
     the algorithm is called the
     "Universal RDF Graph Canonicalization Algorithm 2012"
-    (<abbr title="Universal RDF Graph Canonicalization Algorithm 2012"><dfn>URGNA2012</dfn></abbr>),
+    (<abbr title="Universal RDF Graph Canonicalization Algorithm 2012"><dfn class="export">URGNA2012</dfn></abbr>),
     and differs from the stated algorithm in the following ways:</p>
   <ul>
     <li>In <a href="#hash-first-degree-quads" class="sectionRef"></a>, if any blank node was used in the <a>graph name</a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1,0 +1,915 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta content="text/html; charset=utf-8" http-equiv="content-type" />
+<meta content="width=device-width,initial-scale=1" name="viewport" />
+<title>RDF Dataset Canonicalization</title>
+<script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+<!--script class="remove" src="../replace-ed-uris.js"></script -->
+<script class="remove">
+//<![CDATA[
+  var respecConfig = {
+      doJsonLd: true,
+      // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
+      specStatus:           "CG-DRAFT",
+      //publishDate:          "2010-04-29",
+      copyrightStart:       "2010",
+
+      // the specification's short name, as in http://www.w3.org/TR/short-name/
+      shortName:            "rdf-dataset-canonicalization",
+      subtitle:             "A Standard RDF Dataset Canonicalization Algorithm",
+      // if you wish the publication date to be other than today, set this
+      // publishDate:  "2009-08-06",
+
+      // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+      // and its maturity status
+      //previousPublishDate:  "2011-08-17",
+      //previousMaturity:     "ED",
+      //previousDiffURI:      "https://json-ld.org/spec/ED/20110817/index.html",
+      //diffTool:             "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+
+      // if there a publicly available Editor's Draft, this is the link
+      edDraftURI:           "https://json-ld.github.io/rdf-dataset-canonicalization/spec/",
+
+      github: {
+        repoURL: "https://github.com/json-ld/rdf-dataset-canonicalization/",
+          branch: "main"
+      },
+
+      // if this is a LCWD, uncomment and set the end of its review period
+      // lcEnd: "2009-08-05",
+
+      // if you want to have extra CSS, append them to this list
+      // it is recommended that the respec.css stylesheet be kept
+      // extraCSS: [],
+
+      // editors, add as many as you like
+      // only "name" is required
+      editors:  [
+          { name: "Dave Longley", url: "https://digitalbazaar.com/",
+            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/"},
+          { name: "Manu Sporny", url: "http://manu.sporny.org/",
+            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/" }
+      ],
+
+      // authors, add as many as you like.
+      // This is optional, uncomment if you have authors as well as editors.
+      // only "name" is required. Same format as editors.
+      authors:  [
+          { name: "Dave Longley", url: "https://digitalbazaar.com/",
+            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/"}
+      ],
+
+      // name of the 
+      group: "credentials",
+
+      // URI of the public WG page
+      wgURI: "https://www.w3.org/community/credentials/",
+
+      // name (with the @w3c.org) of the public mailing to which comments are due
+      wgPublicList: "public-credentials-wg@w3.org",
+      wgPatentURI:  "https://www.w3.org/Consortium/Patent-Policy-20200915/",
+      maxTocLevel: 2
+  };
+//]]>
+</script>
+<style type="text/css">
+  .highlight { font-weight: bold; color: #0a3; }
+  .comment { color: #999; }
+  table, thead, tr, td { padding: 5px; border-width: 1px; border-spacing: 0px; border-style: solid; border-collapse: collapse; }
+  ol.algorithm {
+    counter-reset: numsection;
+    list-style-type: none;
+  }
+  ol.algorithm li {
+    margin: 0.5em 0;
+  }
+  ol.algorithm li:before {
+    font-weight: bold;
+    counter-increment: numsection;
+    content: counters(numsection, ".") ") ";
+  }
+  a.externalDFN {border-bottom:  1px solid #99c; font-style: italic;}
+</style>
+</head>
+
+<body>
+<section id="abstract">
+  <p>RDF [[RDF-CONCEPTS]] describes a graph-based data model for making claims
+    about the world and provides the foundation for reasoning upon that graph
+    of information. At times, it becomes necessary to compare the differences
+    between sets of graphs, digitally sign them, or generate short identifiers
+    for graphs via hashing algorithms. This document outlines an algorithm for
+    normalizing <a>RDF datasets</a> such that these operations can be
+    performed.</p>
+</section>
+
+<section id="sotd">
+  <p>This document is a work in progress.</p>
+  <!-- <p>This document has been reviewed by W3C Members, by software
+    developers, and by other W3C groups and interested parties, and is
+    endorsed by the Director as a W3C Recommendation. It is a stable
+    document and may be used as reference material or cited from another
+    document. W3C's role in making the Recommendation is to draw attention
+    to the specification and to promote its widespread deployment. This
+    enhances the functionality and interoperability of the Web.</p> -->
+</section>
+
+<section>
+  <h2>Introduction</h2>
+
+  <p>When data scientists discuss canonicalization, they do so in the context of
+    achieving a particular set of goals. Since the same information may
+    sometimes be expressed in a variety of different ways, it often becomes
+    necessary to be able to transform each of these different ways into a
+    single, standard format. With a standard format, the differences between
+    two different sets of data can be easily determined, a
+    cryptographically-strong hash identifier can be generated for a particular
+    set of data, and a particular set of data may be digitally-signed for later
+    verification.</p>
+
+  <p>In particular, this specification is about normalizing
+    <a>RDF datasets</a>, which are collections of graphs. Since
+    a directed graph can express the same information in more than one
+    way, it requires canonicalization to achieve the aforementioned goals
+    and any others that may arise via serendipity.</p>
+
+  <p>Most <a>RDF datasets</a> can be normalized fairly quickly, in terms
+    of algorithmic time complexity. However, those that contain nodes that do
+    not have globally unique identifiers pose a greater challenge. Normalizing
+    these datasets presents the <dfn>graph isomorphism</dfn> problem, a
+    problem that is believed to be difficult to solve quickly. More formally,
+    it is believed to be an NP-Intermediate problem, that is, neither known to
+    be solvable in polynomial time nor NP-complete. Fortunately, existing real
+    world data is rarely modeled in a way that manifests this problem and new
+    data can be modeled to avoid it. In fact, software systems can detect a
+    problematic dataset and may choose to assume it's an attempted denial of
+    service attack, rather than a real input, and abort.</p>
+
+  <p>This document outlines an algorithm for generating a normalized
+    <a>RDF dataset</a> given an <a>RDF dataset</a> as input. The
+    algorithm is called the
+    <strong>Universal RDF Dataset Canonicalization Algorithm 2015</strong> or
+    <a>URDNA2015</a>.</p>
+
+  <div class="issue" data-number="2"></div>
+  <section>
+    <h2>Uses of Dataset Canonicalization</h2>
+    <p>There are different use cases where graph or dataset canonicalization are important:</p>
+    <ul>
+      <li>Determining if one serialization is isomorphic to another.</li>
+      <li>Digital signing of graphs (datasets) independent of serialization or format.</li>
+      <li>Comparing two graphs (datasets) to find differences.</li>
+      <li>Communicating change sets when remotely updating an <a data-cite="RDF11-CONCEPTS#dfn-rdf-source">RDF source</a>.</li>
+    </ul>
+    <p>A canonicalization algorithm is necessary, but not necessarily sufficient, to handle many of these use cases. The use of <a>blank nodes</a> in RDF graphs and datasets has a long history and creates inevitable complexities. Blank nodes are used for different purposes:</p>
+    <ul>
+      <li>when a well known identifier for a node is not known, or the author of a document chooses not to unambiguously name that node,</li>
+      <li>when a node is used to stitch together parts of a graph and the nodes themselves are not interesting (e.g., <a data-cite="RDF11-MT#rdf-collections">RDF Collections</a> in [[RDF-MT]]),</li>
+      <li>when someone is trying to create an intentionally difficult graph topology.</li>
+    </ul>
+    <p>Further more, RDF semantics dictate that deserializing the same RDF document results in the creation of unique <a>blank nodes</a>, unless it can be determined that on each occasion, the <a>blank node identifiers</a> the same resource; this is due to the fact that <a>blank node identifiers</a> are an aspect of a concrete RDF syntax and are not intended to be persistent or portable. Within the abstract RDF model, blank nodes do not have identifiers (although some <a data-cite="RDF11-CONCEPTS#dfn-rdf-store">RDF store</a> implementations may use stable identifiers and choose to make them portable). See <cite><a data-cite="RDF11-CONCEPTS#section-blank-nodes">Blank Nodes</a></cite> in [[!RDF-CONCEPTS]] for more information.</p>
+    <p>RDF does have a provision for allowing blank nodes to be published in an externally identifiable way through the use of <a data-cite="RDF11-CONCEPTS#dfn-skolem-iri">Skolem IRIs</a>, which allows a given RDF store to replace the use of blank nodes in a concrete syntax with IRIs, which serve to repeatably identify that blank node within that particular RDF store, however, this is not generally useful for talking about the same graph in different RDF stores, or other concrete representations. In any case, a stable <a>blank node identifier</a> defined for one RDF store, serialization is arbitrary, and typically not relatable to the context within which it is used.</p>
+    <p>This specification defines an algorithm for creating stable <a>blank node identifiers</a> repeatably for different serializations possibly using individualized <a>blank node identifiers</a> of the same RDF graph (dataset) by grounding each <a>blank node</a> through the nodes to which it is connected, essentially creating <em>Skolem <a>blank node identifiers</a></em>. As a result, a graph signature can be obtained by hashing a canonical serialization of the resulting <a>normalized dataset</a>, allowing for the isomorphism and digital signing use cases. As blank node identifiers can be stable even with other changes to a graph (dataset), in some cases it is possible to compute the difference between two graphs (datasets), for example if changes are made only to ground triples, or if new blank nodes are introduced which do not create an automorphic confusion with other existing blank nodes. If any information which would change the generated blank node identifier, a resulting diff might indicate a greater set of changes than actually exists.</p>
+    <p class="ednote">TimBL has a <a href="http://www.w3.org/DesignIssues/Diff">design note</a> on problems with Diff which should be referenced.</p>
+    <p class="ednote">Jerremy Carroll has a <a href="http://www.hpl.hp.com/techreports/2003/HPL-2003-142.pdf">paper</a> on signing RDF graphs.</p>
+  </section>
+
+  <section>
+    <h2>How to Read this Document</h2>
+
+    <p>This document is a detailed specification for an <a>RDF dataset</a>
+      canonicalization algorithm. The document is primarily intended for the
+      following audiences:</p>
+
+    <ul>
+      <li>Software developers that want to implement an <a>RDF dataset</a>
+        canonicalization algorithm.</li>
+      <li>Masochists.</li>
+    </ul>
+
+    <p>To understand the basics in this specification you must be familiar with
+      basic RDF concepts [[!RDF-CONCEPTS]]. A working knowledge of
+      <a href="https://en.wikipedia.org/wiki/Graph_theory">graph theory</a> and
+      <a href="https://en.wikipedia.org/wiki/Graph_isomorphism">graph isomorphism</a>
+      is also recommended.</p>
+  </section>
+
+  <section>
+    <h2>Contributing</h2>
+
+    <p>There are a number of ways that one may participate in the development
+      of this specification:</p>
+
+    <ul>
+      <li>Technical discussion typically occurs on the public mailing list:
+        <a href="http://lists.w3.org/Archives/Public/public-credentials/">public-credentials@w3.org</a></li>
+
+      <li><a href="https://opencreds.org/minutes/">Public teleconferences</a> are
+        held on Tuesdays at 1600UTC every week of each month.</li>
+
+      <li>Specification bugs and issues should be reported in the
+        <a href="https://github.com/json-ld/rdf-dataset-canonicalization/issues">issue tracker</a>.</li>
+
+      <li><a href="https://github.com/json-ld/rdf-dataset-canonicalization/tree/main/spec">Source code</a> for the
+        specification can be found on GitHub.</li>
+
+      <li>The <a href="https://webchat.freenode.net/?channels=#credentials">#credentials</a>
+        IRC channel is available for real-time discussion on
+        <a href="irc.freenode.net">irc.freenode.net.</a></li>
+    </ul>
+  </section>
+</section>
+
+<section id="conformance"></section>
+
+<section class="normative">
+  <h2>Terminology</h2>
+
+  <section class="normative">
+    <h2>General Terminology</h2>
+
+    <dl>
+      <dt><dfn>string</dfn></dt><dd>
+        A string is a sequence of zero or more Unicode characters.</dd>
+      <dt><code>true</code> and <code>false</code></dt><dd>
+        Values that are used to express one of two possible boolean states.</dd>
+      <dt><dfn data-lt="internationalized resource identifier|iri|iris"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt>
+      <dd>An <a>IRI</a> (Internationalized Resource Identifier) is a string that conforms to the syntax
+        defined in [[RFC3987]].</dd>
+      <dt><dfn data-lt="subject|subjects">subject</dfn></dt>
+      <dd>A <a data-cite="RDF11-CONCEPTS#dfn-subject">subject</a>
+        as specified by [[!RDF11-CONCEPTS]].</dd>
+      <dt><dfn data-lt="predicate|predicates">predicate</dfn></dt>
+      <dd>A <a data-cite="RDF11-CONCEPTS#dfn-predicate">predicate</a>
+        as specified by [[!RDF11-CONCEPTS]].</dd>
+      <dt><dfn data-lt="object|objects">object</dfn></dt>
+      <dd>An <a data-cite="RDF11-CONCEPTS#dfn-object">object</a>
+        as specified by [[!RDF11-CONCEPTS]].</dd>
+      <dt><dfn data-lt="rdf triple|rdf triples|triple|triples">RDF triple</dfn></dt>
+      <dd>A <a data-cite="RDF11-CONCEPTS#dfn-triple">triple</a>
+        as specified by [[!RDF11-CONCEPTS]].</dd>
+      <dt><dfn data-lt="rdf graph|rdf graphs|graph|graphs">RDF graph</dfn></dt>
+      <dd>An <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graph</a>
+        as specified by [[!RDF11-CONCEPTS]].</dd>
+      <dt><dfn data-lt="graph name|graph names">graph name</dfn></dt>
+      <dd>A <a data-cite="RDF11-CONCEPTS#dfn-graph-name">graph name</a>
+        as specified by [[!RDF11-CONCEPTS]].</dd>
+      <dt><dfn data-lt="quad|quads">quad</dfn></dt>
+      <dd>A tuple composed of <a>subject</a>, <a>predicate</a>, <a>object</a>, and <a>graph name</a>.
+        This is a generalization of an <a>RDF triple</a> along with a <a>graph name</a>.</dd>
+      <dt><dfn data-lt="rdf dataset|rdf datasets|dataset|datasets">RDF dataset</dfn></dt>
+      <dd>A <a data-cite="RDF11-CONCEPTS#dfn-rdf-dataset">dataset</a>
+        as specified by [[!RDF11-CONCEPTS]].
+        For the purposes of this specification, an <a>RDF dataset</a>
+        is considered to be a set of <a>quads</a></dd>
+      <dt><dfn data-lt="blank node|blank nodes">blank node</dfn></dt>
+      <dd>A <a data-cite="RDF11-CONCEPTS#dfn-blank-node">blank node</a>
+        as specified by [[!RDF11-CONCEPTS]]. In short, it is a node in a graph that is
+        neither an <a>IRI</a>, nor a
+        <a data-cite="RDF11-CONCEPTS#dfn-literal">literal</a>.</dd>
+      <dt><dfn data-lt="blank node identifier|blank node identifiers">blank node identifier</dfn></dt>
+      <dd>A <a data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a>
+        as specified by [[!RDF11-CONCEPTS]]. In short, it is a <a>string</a> that begins
+        with <code>_:</code> that is used as an identifier for an
+        <a>blank node</a>. <a>Blank node identifiers</a>
+        are typically implementation-specific local identifiers; this document
+        specifies an algorithm for deterministically specifying them.</dd>
+    </dl>
+  </section>
+</section>
+
+<section>
+  <h2>Canonicalization</h2>
+
+  <p>Canonicalization is the process of transforming an
+    <a>input dataset</a> to a <a>normalized dataset</a>. That
+    is, any two <a>input datasets</a> that contain the same
+    information, regardless of their arrangement, will be transformed into
+    identical <a>normalized dataset</a>. The problem requires directed
+    graphs to be deterministically ordered into sets of nodes and edges. This
+    is easy to do when all of the nodes have globally-unique identifiers, but
+    can be difficult to do when some of the nodes do not. Any nodes without
+    globally-unique identifiers must be issued deterministic identifiers.</p>
+
+  <p class="ednote">Strictly speaking, the normalized dataset must be serialized to be stable, as within a dataset, blank node identifiers have no meaning. This specification defines a <a>normalized dataset</a> to include stable identifiers for blank nodes, but practical uses of this will always generate a canonical serialization of such a dataset.</p>
+
+  <p>In time, there may be more than one canonicalization algorithm and,
+    therefore, for identification purposes, this algorithm is named the
+    "Universal RDF Dataset Canonicalization Algorithm 2015"
+    (<abbr title="Universal RDF Dataset Canonicalization Algorithm 2015"><dfn>URDNA2015</dfn></abbr>).</p>
+
+  <p class="ednote">This statement is overly prescriptive and does not include normative language.
+    This spec should describe the theoretical basis for graph canonicalization and describe
+    behavior using normative statements. The explicit algorithms should follow as an informative appendix.</p>
+
+  <section>
+    <h2>Canonicalization Algorithm Terms</h2>
+    <dl>
+      <dt><dfn data-lt="input dataset|input datasets">input dataset</dfn></dt>
+      <dd>The abstract <a>RDF dataset</a> that is provided as input to
+        the algorithm.</dd>
+      <dt><dfn>normalized dataset</dfn></dt>
+      <dd>The immutable, abstract <a>RDF dataset</a> and set of normalized
+        <a>blank node identifiers</a> that are produced as output by the algorithm. A <a>normalized dataset</a> is a restriction on an <a>RDF dataset</a> where all nodes are labeled, and <a>blank nodes</a> are labeled with <a>blank node identifiers</a> consistent with running this algorithm on a base <a>RDF dataset</a>. A concrete serialization of an <a>normalized dataset</a> MUST label all <a>blank nodes</a> using these stable <a>blank node identifiers</a>.</dd>
+      <dt><dfn>identifier issuer</dfn></dt>
+      <dd>An identifier issuer is used to issue new <a>blank node identifier</a>. It
+        maintains a
+        <a href="#blank-node-identifier-issuer-state">blank node identifier issuer state</a>.</dd>
+      <dt><dfn>hash</dfn></dt>
+      <dd>The lowercase, hexadecimal representation of a message digest.</dd>
+      <dt><dfn>hash algorithm</dfn></dt>
+      <dd>The hash algorithm used by <a>URDNA2015</a>, namely, SHA-256.</dd>
+    </dl>
+  </section>
+
+  <section>
+    <h2>Canonicalization State</h2>
+
+    <p>When performing the steps required by the canonicalization algorithm,
+      it is helpful to track state in a data structure called the
+      <dfn>canonicalization state</dfn>. The information contained in the
+      <a>canonicalization state</a> is described below.</p>
+
+    <dl>
+      <dt><dfn>blank node to quads map</dfn></dt>
+      <dd>A data structure that maps a <a>blank node identifier</a> to
+        the <a>quads</a> in which they appear in the
+        <a>input dataset</a>.</dd>
+      <dt><dfn>hash to blank nodes map</dfn></dt>
+      <dd>A data structure that maps a <a>hash</a> to a list of
+        <a>blank node identifiers</a>.</dd>
+      <dt><dfn>canonical issuer</dfn></dt>
+      <dd>An <a>identifier issuer</a>, initialized with the
+        prefix <code>_:c14n</code>, for issuing canonical
+        <a>blank node identifiers</a>.
+        <div class="issue">
+          Mapping all <a>blank nodes</a> to use this
+          identifier spec means that an <a>RDF dataset</a> composed of two
+          different <a>RDF graphs</a> will use different
+          identifiers then that for the graphs taken independently. This may
+          happen anyway, due to <a
+          href="https://en.wikipedia.org/wiki/Automorphism">automorphisms</a>,
+          or overlapping statements, but an identifier based on the resulting
+          <a>hash</a> along with an issue sequence number specific to that <a>hash</a> would
+          stand a better chance of surviving such minor changes, and allow the
+          resulting information to be useful for <a href="https://www.w3.org/2001/sw/wiki/How_to_diff_RDF">RDF Diff</a>.
+        </div>
+      </dd>
+    </dl>
+  </section>
+
+  <section>
+    <h2>Blank Node Identifier Issuer State</h2>
+
+    <p>During the canonicalization algorithm, it is sometimes necessary to
+      issue new identifiers to <a>blank nodes</a>. The
+      <a href="#issue-identifier">Issue Identifier algorithm</a> uses an
+      <a>identifier issuer</a> to accomplish this task. The information
+      an <a>identifier issuer</a> needs to keep track of is described
+      below.</p>
+
+    <dl>
+      <dt><dfn>identifier prefix</dfn></dt>
+      <dd>The identifier prefix is a string that is used at the beginning of an
+        <a>blank node identifier</a>. It should be initialized to a
+        string that is specified by the canonicalization algorithm. When
+        generating a new <a>blank node identifier</a>, the prefix
+        is concatenated with a <a>identifier counter</a>. For example,
+        <code>_:c14n</code> is a proper initial value for the
+        <a>identifier prefix</a> that would produce
+        <a>blank node identifiers</a> like <code>_:c14n1</code>.</dd>
+      <dt><dfn>identifier counter</dfn></dt>
+      <dd>A counter that is appended to the <a>identifier prefix</a> to
+        create an <a>blank node identifier</a>. It is initialized to
+        <code>0</code>.</dd>
+      <dt><dfn>issued identifiers list</dfn></dt>
+      <dd>A list that tracks previously issued identifiers in the order in
+        which they were issued. It also tracks the existing identifier that
+        triggered the issuance, to prevent issuing more than one new identifier
+        per existing identifier, and to allow <a>blank nodes</a> to
+        be reassigned identifiers some time after issuance.</dd>
+    </dl>
+  </section>
+
+  <section>
+    <h2>Canonicalization Algorithm</h2>
+
+    <p>The canonicalization algorithm converts an <a>input dataset</a>
+      into a <a>normalized dataset</a>. This algorithm will assign
+      deterministic identifiers to any <a>blank nodes</a> in the
+      <a>input dataset</a>.</p>
+
+    <p class="ednote">Documenting the algorithm is a WIP, various steps will
+      become more detailed in time.</p>
+
+    <p class="ednote">See the note for the hash first degree quads
+      algorithm. We should either remove the loop based on
+      <code>simple</code> here but indicate that the original design
+      of the algorithm was to have such a loop, or leave it but
+      inform implementers that it is safe to break after one iteration
+      of the loop (again, indicating why). A future version of this
+      algorithm should make the loop effectual.
+    </p>
+
+    <section class="informative">
+      <h3>Overview</h3>
+    </section>
+
+    <section>
+      <h3>Algorithm</h3>
+
+      <ol class="algorithm">
+        <li>Create the <a>canonicalization state</a>.</li>
+        <li>For every <a>quad</a> in <a>input dataset</a>:
+          <ol class="algorithm">
+            <li>For each <a>blank node</a> that occurs in the
+              <a>quad</a>, add a reference to the
+              <a>quad</a> using the
+              <a>blank node identifier</a> in the
+              <a>blank node to quads map</a>, creating a new entry if
+              necessary.
+              <div class="issue">It seems that quads must be normalized, so that literals with different syntactic representations but the same semantic representations are merged, and that two graphs differing in the syntactic representation of a literal will produce the same set of blank node identifiers.</div>
+            </li>
+          </ol>
+        </li>
+        <li>Create a list of non-normalized <a>blank node identifiers</a>
+          <var>non-normalized identifiers</var> and populate it using the keys
+          from the <a>blank node to quads map</a>.</li>
+        <li>Initialize <var>simple</var>, a boolean flag, to
+          <code>true</code>.</li>
+        <li>While <var>simple</var> is <code>true</code>,
+          issue canonical identifiers for <a>blank nodes</a>:
+          <ol class="algorithm">
+            <li>Set <var>simple</var> to <code>false</code>.</li>
+            <li>Clear <a>hash to blank nodes map</a>.</li>
+            <li>For each <a>blank node identifier</a>
+              <var>identifier</var> in <var>non-normalized identifiers</var>:
+              <ol class="algorithm">
+                <li>Create a <a>hash</a>, <var>hash</var>, according to the
+                  <a href="#hash-first-degree-quads">Hash First Degree Quads algorithm</a>.</li>
+                <li>Add <var>hash</var> and <var>identifier</var> to
+                  <a>hash to blank nodes map</a>, creating a new entry if
+                  necessary.</li>
+              </ol>
+            </li>
+            <li>For each <var>hash</var> to <var>identifier list</var> mapping in
+              <a>hash to blank nodes map</a>, lexicographically-sorted by
+              <var>hash</var>:
+              <ol class="algorithm">
+                <li>If the length of <var>identifier list</var> is greater than
+                  <code>1</code>, continue to the next mapping.</li>
+                <li>Use the
+                  <a href="#issue-identifier">Issue Identifier algorithm</a>,
+                  passing <a>canonical issuer</a> and the
+                  single <a>blank node identifier</a> in
+                  <var>identifier list</var>, <var>identifier</var>, to issue a
+                  canonical replacement identifier for <var>identifier</var>.</li>
+                <li>Remove <var>identifier</var> from
+                  <var>non-normalized identifiers</var>.</li>
+                <li>Remove <var>hash</var> from the
+                  <a>hash to blank nodes map</a>.</li>
+                <li>Set <var>simple</var> to <code>true</code>.</li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>For each <var>hash</var> to <var>identifier list</var> mapping in
+          <a>hash to blank nodes map</a>, lexicographically-sorted by
+          <var>hash</var>:
+          <ol class="algorithm">
+            <li>Create <var>hash path list</var> where each item will be a result
+              of running the
+              <a href="#hash-n-degree-quads">Hash N-Degree Quads algorithm</a>.</li>
+            <li>For each <a>blank node identifier</a>
+              <var>identifier</var> in <var>identifier list</var>:
+              <ol class="algorithm">
+                <li>If a canonical identifier has already been issued for
+                  <var>identifier</var>, continue to the next
+                  <var>identifier</var>.</li>
+                <li>Create <var>temporary issuer</var>, an
+                  <a>identifier issuer</a> initialized with the prefix
+                  <code>_:b</code>.</li>
+                <li>Use the
+                  <a href="#issue-identifier">Issue Identifier algorithm</a>,
+                  passing <var>temporary issuer</var> and <var>identifier</var>, to
+                  issue a new temporary <a>blank node identifier</a>
+                  for <var>identifier</var>.</li>
+                <li>Run the
+                  <a href="#hash-n-degree-quads">Hash N-Degree Quads algorithm</a>,
+                  passing <var>temporary issuer</var>, and append the
+                  result to the <var>hash path list</var>.</li>
+              </ol>
+            </li>
+            <li>For each <var>result</var> in the <var>hash path list</var>,
+              lexicographically-sorted by the <var>hash</var> in <var>result</var>:
+              <ol class="algorithm">
+                <li>For each <a>blank node identifier</a>,
+                  <var>existing identifier</var>, that was issued a temporary
+                  identifier by <var>identifier issuer</var> in <var>result</var>, issue
+                  a canonical identifier, in the same order, using the
+                  <a href="#issue-identifier">Issue Identifier algorithm</a>,
+                  passing <a>canonical issuer</a> and
+                  <var>existing identifier</var>.
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>For each <a>quad</a>, <var>quad</var>, in
+          <a>input dataset</a>:
+          <ol class="algorithm">
+            <li>Create a copy, <var>quad copy</var>, of <var>quad</var> and replace any
+              existing <a>blank node identifier</a>s using the
+              canonical identifiers previously issued
+              by <a>canonical issuer</a>.</li>
+            <li>Add <var>quad copy</var> to the
+              <a>normalized dataset</a>.</li>
+          </ol>
+        </li>
+        <li>Return the <a>normalized dataset</a>.</li>
+      </ol>
+    </section>
+  </section>
+
+  <section id="issue-identifier">
+    <h2>Issue Identifier Algorithm</h2>
+
+    <section class="informative">
+      <h3>Overview</h3>
+    </section>
+
+    <section>
+      <h3>Algorithm</h3>
+    </section>
+
+    <p>This algorithm issues a new <a>blank node identifier</a> for
+      a given existing <a>blank node identifier</a>. It also updates
+      state information that tracks the order in which new
+      <a>blank node identifiers</a> were issued.</p>
+
+    <p>This algorithm takes an <a>identifier issuer</a> and an
+      <var>existing identifier</var> as inputs. The output is a new
+      <var>issued identifier</var>. The steps of the algorithm are:</p>
+
+    <ol class="algorithm">
+      <li>If there is already an issued identifier for
+        <var>existing identifier</var> in <a>issued identifiers list</a>,
+        return it.</li>
+      <li>Generate <var>issued identifier</var> by concatenating
+        <a>identifier prefix</a> with the string value of
+        <a>identifier counter</a>.</li>
+      <li>Append an item to <a>issued identifiers list</a> that maps
+        <var>existing identifier</var> to <var>issued identifier</var>.</li>
+      <li>Increment <a>identifier counter</a>.</li>
+      <li>Return <var>issued identifier</var>.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Hash First Degree Quads</h2>
+
+    <p class="ednote">Add note that the result of this algorithm for a
+      particular blank node will always be the same. This is only true
+      because there was a typo in the spec that has now been implemented
+      by many implementations. The design of the algorithm was to use the
+      assigned canonical blank node identifier, if available, instead of
+      <code>_:a</code> or <code>_:z</code>, similar to how it is used in
+      the related hash algorithm, but this text never made it into the spec
+      before implementations moved forward. Therefore, the hashes here
+      never change, making the loop based on the <code>simple</code>
+      flag that calls this algorithm unnecessary; it needs to only run
+      once. A future version of this algorithm should correct this mistake.
+    </p>
+
+    <section class="informative">
+      <h3>Overview</h3>
+    </section>
+
+    <section>
+      <h3>Algorithm</h3>
+
+      <p>This algorithm takes the <a>canonicalization state</a> and a
+        <dfn>reference blank node identifier</dfn> as inputs.</p>
+
+      <ol class="algorithm">
+        <li>Initialize <dfn>nquads</dfn> to an empty list. It will be
+          used to store quads in N-Quads format.</li>
+        <li>Get the list of <a>quads</a> <var>quads</var> associated with the
+          <a>reference blank node identifier</a> in the
+          <a>blank node to quads map</a>.</li>
+        <li>For each <a>quad</a> <var>quad</var> in <var>quads</var>:
+          <ol class="algorithm">
+            <li>Serialize the <a>quad</a> in N-Quads format with the
+              following special rule:
+              <ol class="algorithm">
+                <li>If any component in <var>quad</var> is an
+                  <a>blank node</a>, then serialize it using a
+                  special identifier as follows:
+                  <ol class="algorithm">
+                    <li>If the <a>blank node</a>'s existing
+                    <a>blank node identifier</a> matches the
+                    <a>reference blank node identifier</a> then use the
+                    <a>blank node identifier</a> <code>_:a</code>,
+                    otherwise, use the <a>blank node identifier</a>
+                    <code>_:z</code>.</li>
+                  </ol>
+                </li>
+              </ol>
+              <p class="issue">Note potential need to normalize literals to their canonical representation here as well, if not done on the original <a>input dataset</a>.</p>
+            </li>
+          </ol>
+        </li>
+        <li>Sort <a>nquads</a> in lexicographical order.</li>
+        <li>Return the <a>hash</a> that results from passing the sorted,
+          joined <a>nquads</a> through the
+          <a>hash algorithm</a>.</li>
+      </ol>
+    </section>
+  </section>
+
+  <section>
+    <h2>Hash Related Blank Node</h2>
+
+    <section class="informative">
+      <h3>Overview</h3>
+    </section>
+
+    <section>
+      <h3>Algorithm</h3>
+
+      <p>This algorithm creates a <a>hash</a> to identify how one
+        <a>blank node</a> is related to another. It takes the
+        <a>canonicalization state</a>, a <var>related</var>
+        <a>blank node identifier</a>, a <var>quad</var>, an
+        <a>identifier issuer</a>, <var>issuer</var>, and a
+        <a>string</a> <var>position</var> as inputs.</p>
+
+      <ol class="algorithm">
+        <li>Set the <var>identifier</var> to use for <var>related</var>, preferring
+          first the canonical identifier for <var>related</var> if issued, second
+          the identifier issued by <var>issuer</var> if issued, and last, if
+          necessary, the result of the
+          <a href="#hash-first-degree-quads">Hash First Degree Quads algorithm</a>,
+          passing <var>related</var>.
+        </li>
+        <li>Initialize a <a>string</a> <var>input</var> to the value of
+          <var>position</var>.</li>
+        <li>If <var>position</var> is not <code>g</code>, append
+          <code>&lt;</code>, the value of the <a>predicate</a> in
+          <var>quad</var>, and <code>&gt;</code> to <var>input</var>.</li>
+        <li>Append <var>identifier</var> to <var>input</var>.</li>
+        <li>Return the <a>hash</a> that results from passing <var>input</var>
+          through the <a>hash algorithm</a>.</li>
+      </ol>
+    </section>
+  </section>
+
+  <section>
+    <h2>Hash N-Degree Quads</h2>
+
+    <p class="ednote">The relationship and difference between this algorithm
+      and the hash first degree quads algorithm should be better explained.
+      There may also be better names for the two algorithms.</p>
+
+    <p class="ednote">The 'path' terminology could also be changed to better
+      indicate what a path is (a particular deterministic serialization for
+      a subgraph/subdataset of nodes without globally-unique identifiers).</p>
+
+    <section class="informative">
+      <h3>Overview</h3>
+
+      <p>Usually, when trying to determine if two nodes in a graph are
+        equivalent, you simply compare their identifiers. However, what if the
+        nodes don't have identifiers? Then you must determine if the two nodes
+        have equivalent connections to equivalent nodes all throughout the
+        whole graph. This is called the <a>graph isomorphism</a> problem. This
+        algorithm approaches this problem by considering how one might draw
+        a graph on paper. You can test to see if two nodes are equivalent
+        by drawing the graph twice. The first time you draw the graph the
+        first node is drawn in the center of the page. If you can draw the
+        graph a second time such that it looks just like the first, except
+        the second node is in the center of the page, then the nodes are
+        equivalent. This algorithm essentially defines a deterministic way to
+        draw a graph where, if you begin with a particular node, the graph
+        will always be drawn the same way. If two graphs are drawn the same way
+        with two different nodes, then the nodes are equivalent. A
+        <a>hash</a> is used to indicate a particular way that the graph
+        has been drawn and can be used to compare nodes.</p>
+
+      <p>This algorithm works in concert with the main canonicalization algorithm
+        to produce a unique, deterministic identifier for a particular blank
+        node. This <a>hash</a> incorporates all of the information that
+        is connected to the blank node as well as how it is connected. It does
+        this by creating deterministic paths that emanate out from the blank
+        node through any other adjacent blank nodes.</p>
+    </section>
+
+    <section>
+      <h3>Algorithm</h3>
+
+      <div class="issue">
+        An additional input to this algorithm should be added that
+        allows it to be optionally skipped and throw an error if any
+        equivalent related hashes were produced that must be permuted
+        during step 5.4.4. For practical uses of the algorithm, this step
+        should never be encountered and could be turned off, disabling
+        canonizing datasets that include a need to run it as a security
+        measure.
+      </div>
+
+      <p>The inputs to this algorithm are the <a>canonicalization state</a>,
+        the <var>identifier</var> for the <a>blank node</a> to
+        recursively hash quads for, and path identifier <var>issuer</var> which is
+        an <a>identifier issuer</a> that issues temporary
+        <a>blank node identifier</a>s. The output from this algorithm
+        will be a <a>hash</a> and the <a>identifier issuer</a> used
+        to help generate it.</p>
+
+      <ol class="algorithm">
+        <li>Create a <var>hash to related blank nodes map</var> for storing
+          hashes that identify related <a>blank nodes</a>.</li>
+        <li>Get a reference, <var>quads</var>, to the list of <a>quads</a>
+          in the <a>blank node to quads map</a> for the key
+          <var>identifier</var>.</li>
+        <li>For each <var>quad</var> in <var>quads</var>:
+          <ol class="algorithm">
+            <li>For each <var>component</var> in <var>quad</var>, where <var>component</var>
+              is the <a>subject</a>, <a>object</a>, or
+              <a>graph name</a>, and it is a
+              <a>blank node</a> that is not identified by
+              <var>identifier</var>:
+              <ol class="algorithm">
+                <li>Set <var>hash</var> to the result of the
+                  <a href="#hash-related-blank-node">Hash Related Blank Node algorithm</a>,
+                  passing the <a>blank node identifier</a> for
+                  <var>component</var> as <var>related</var>, <var>quad</var>,
+                  <var>path identifier issuer</var> as <var>issuer</var>, and
+                  <var>position</var> as either <code>s</code>, <code>o</code>, or
+                  <code>g</code> based on whether <var>component</var> is a
+                  <a>subject</a>, <a>object</a>,
+                  <a>graph name</a>, respectively.</li>
+                <li>Add a mapping of <var>hash</var> to the
+                  <a>blank node identifier</a> for <var>component</var>
+                  to <var>hash to related blank nodes map</var>, adding an entry
+                  as necessary.</li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>Create an empty string, <var>data to hash</var>.</li>
+        <li>For each <var>related hash</var> to <var>blank node list</var> mapping in
+          <var>hash to related blank nodes map</var>, sorted lexicographically
+          by <var>related hash</var>:
+          <ol class="algorithm">
+            <li>Append the <var>related hash</var> to the <var>data to hash</var>.</li>
+            <li>Create a <a>string</a> <var>chosen path</var>.</li>
+            <li>Create an unset <var>chosen issuer</var> variable.</li>
+            <li>For each <var>permutation</var> of <var>blank node list</var>:
+              <ol class="algorithm">
+                <li>Create a copy of <var>issuer</var>, <var>issuer copy</var>.</li>
+                <li>Create a <a>string</a> <var>path</var>.</li>
+                <li>Create a <var>recursion list</var>, to store
+                  <a>blank node identifiers</a> that must be
+                  recursively processed by this algorithm.</li>
+                <li>For each <var>related</var> in <var>permutation</var>:
+                  <ol class="algorithm">
+                    <li>If a canonical identifier has been issued for
+                      <var>related</var>, append it to <var>path</var>.</li>
+                    <li>Otherwise:
+                      <ol class="algorithm">
+                        <li>If <i>issuer copy</i> has not issued
+                          an identifier for <var>related</var>, append
+                          <var>related</var> to <var>recursion list</var>.</li>
+                        <li>Use the
+                          <a href="#issue-identifier">Issue Identifier algorithm</a>,
+                          passing <var>issuer copy</var> and <var>related</var> and
+                          append the result to <var>path</var>.</li>
+                      </ol>
+                    </li>
+                    <li>If <var>chosen path</var> is not empty and the length
+                      of <var>path</var> is greater than or equal to the length
+                      of <var>chosen path</var> and <var>path</var> is lexicographically
+                      greater than <var>chosen path</var>, then skip to the next
+                      <var>permutation</var>.
+                    </li>
+                  </ol>
+                </li>
+                <li>For each <var>related</var> in <var>recursion list</var>:
+                  <ol class="algorithm">
+                    <li>Set <var>result</var> to the result of recursively executing
+                      the
+                      <a href="#hash-n-degree-quads">Hash N-Degree Quads algorithm</a>,
+                      passing <var>related</var> for <var>identifier</var> and
+                      <var>issuer copy</var> for <var>path identifier issuer</var>.</li>
+                    <li>Use the
+                      <a href="#issue-identifier">Issue Identifier algorithm</a>,
+                      passing <var>issuer copy</var> and <var>related</var> and
+                      append the result to <var>path</var>.</li>
+                    <li>Append <code>&lt;</code>, the <a>hash</a> in
+                      <var>result</var>, and <code>&gt;</code> to <var>path</var>.</li>
+                    <li>Set <var>issuer copy</var> to the
+                      <a>identifier issuer</a> in result.</li>
+                    <li>If <var>chosen path</var> is not empty and the length
+                      of <var>path</var> is greater than or equal to the length
+                      of <var>chosen path</var> and <var>path</var> is lexicographically
+                      greater than <var>chosen path</var>, then skip to the next
+                      <var>permutation</var>.</li>
+                  </ol>
+                </li>
+                <li>If <var>chosen path</var> is empty or <var>path</var> is
+                  lexicographically less than <var>chosen path</var>, set
+                  <var>chosen path</var> to <var>path</var> and <var>chosen issuer</var>
+                  to <var>issuer copy</var>.</li>
+              </ol>
+            </li>
+            <li>Append <var>chosen path</var> to <var>data to hash</var>.</li>
+            <li>Replace <var>issuer</var>, by reference, with
+              <var>chosen issuer</var>.</li>
+          </ol>
+        </li>
+        <li>Return <var>issuer</var> and the <a>hash</a> that results from
+          passing <var>data to hash</var> through the
+          <a>hash algorithm</a>.</li>
+      </ol>
+    </section>
+  </section>
+</section>
+
+<section>
+  <h2>Use Cases</h2>
+  <p class="ednote">TBD</p>
+</section>
+
+<section>
+  <h2>Examples</h2>
+  <p class="ednote">TBD</p>
+</section>
+
+<section class="appendix">
+  <h2>URGNA2012</h2>
+  <p>A previous version of this algorithm has light deployment. For purposes of identification,
+    the algorithm is called the
+    "Universal RDF Graph Canonicalization Algorithm 2012"
+    (<abbr title="Universal RDF Graph Canonicalization Algorithm 2012"><dfn>URGNA2012</dfn></abbr>),
+    and differs from the stated algorithm in the following ways:</p>
+  <ul>
+    <li>In <a href="#hash-first-degree-quads" class="sectionRef"></a>, if any blank node was used in the <a>graph name</a>
+      position in the <a>quad</a>, then the value was serialized using
+      the special <a>blank node identifier</a>, <code>_:g</code>, instead of <code>_:z</code>.</li>
+    <li>In <a href="#hash-related-blank-node" class="sectionRef"></a>, value of the <a>predicate</a>
+      was not delimited by <code>&lt;</code> and <code>&gt;</code>; there
+      were no delimiters.</li>
+    <li>In <a href="#hash-n-degree-quads" class="sectionRef"></a>, the <var>position</var> parameter passed to
+      the <a href="#hash-related-blank-node">Hash Related Blank Node algorithm</a>
+      was instead modeled as a <var>direction</var> parameter, where it could have
+      the value <code>p</code>, for property, when the related blank node was a
+      <a>subject</a> and the value <code>r</code>, for reverse or reference, when
+      the related blank node was an <a>object</a>. Since <a>URGNA2012</a> only normalized
+      graphs, not datasets, there was no use of the <a>graph name</a> position.</li>
+    <li>In <a href="#hash-n-degree-quads" class="sectionRef"></a>, building the
+      <var>hash to related blank nodes map</var> was done as follows:
+      <ol class="algorithm">
+        <li>For each <var>quad</var> in <var>quads</var>:
+          <ol class="algorithm">
+            <li>If the <var>quad</var>'s <a>subject</a> is a <a>blank node</a> that does not
+              match <var>identifier</var>, set <var>hash</var> to the result of the
+                <a href="#hash-related-blank-node">Hash Related Blank Node algorithm</a>,
+                passing the <a>blank node identifier</a> for
+                <a>subject</a> as <var>related</var>, <var>quad</var>,
+                <var>path identifier issuer</var> as <var>issuer</var>, and
+                <code>p</code> as <var>position</var>.
+            </li>
+            <li>Otherwise, if <var>quad</var>'s <a>object</a> is a <a>blank node</a> that does
+              not match <var>identifier</var>, set <var>hash</var> to the result of the
+                <a href="#hash-related-blank-node">Hash Related Blank Node algorithm</a>,
+                passing the <a>blank node identifier</a> for
+                <a>object</a> as <var>related</var>, <var>quad</var>,
+                <var>path identifier issuer</var> as <var>issuer</var>, and
+                <code>r</code> as <var>position</var>.
+            </li>
+            <li>Otherwise, continue to the next quad.</li>
+            <li>Add a mapping of <var>hash</var> to the
+              <a>blank node identifier</a> for the component
+              that matched (<a>subject</a> or <a>object</a>) to
+              <var>hash to related blank nodes map</var>, adding an entry
+              as necessary.</li>
+          </ol>
+        </li>
+      </ol>
+    </li>
+  </ul>
+</section>
+
+<section class="appendix">
+  <h2>Acknowledgements</h2>
+
+  <p>The editors would like to thank Jeremy Carroll for his work on the
+    graph canonicalization problem, Gavin Carothers for providing valuable
+    feedback and testing input for the algorithm defined in this
+    specification, Sir Tim Berners Lee for his thoughts on graph canonicalization
+    over the years, Jesús Arias Fisteus for his work on a similar
+    algorithm.</p>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
This is based on the [CCG Final Report](https://www.w3.org/community/reports/credentials/CG-FINAL-rdf-dataset-canonicalization-20221009/) with modifications to bring it into the WG.

* Original ReSpec source from https://github.com/w3c-ccg/rdf-dataset-canonicalization/blob/main/spec/index.html.
* Add .pr-preview.
* Update ReSpec config and create bibliographic definitions.
* Add GitHub Actions CI step to validate spec using ReSpec action.

For #12.

(I would have added @dlongley as a reviewer, but he hasn't been added to the repo as of yet).