### PR TITLE
Add CODEOWNERS file to ensure default reviewers.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, these people will be requested for
+# review when someone opens a pull request.
+*       @gkellogg @dlongley


### PR DESCRIPTION
This PR adds a CODEOWNERS file to ensure that there are a default set of reviewers for all PRs and that they're appropriately notified when a PR is raised.