### PR TITLE
Fix entry in Hash First Degree Quads ...

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -576,7 +576,7 @@
               <a>hash to blank nodes map</a>, <a>code point ordered</a> by
               <var>hash</var>:
               <ol>
-                <li id="ca-5-4-1">If  <var>identifier list</var> is not empty,
+                <li id="ca-5-4-1">If  <var>identifier list</var> has more than one entry,
                   continue to the next mapping.</li>
                 <li id="ca-5-4-2">Use the
                   <a href="#issue-identifier">Issue Identifier algorithm</a>,
@@ -686,6 +686,15 @@
 
   <section id="hash-1d-quads" class="algorithm">
     <h2>Hash First Degree Quads</h2>
+
+    <p>This algorithm calculates a <a>hash</a> a given <a>blank node</a>
+      across the <a>quads</a> in a <a>dataset</a> in which that blank node
+      is a component.
+      If this hash uniquely identifies that blank node,
+      no further examination is necessary.
+      Otherwise, a hash will be created for the blank node using
+      the algorithm in <a href="#hash-nd-quads" class="sectionRef"></a>
+      in <a href="#canon-algorithm" class="sectionRef"></a>.</p>
 
     <p class="issue" data-number="23">The result of this algorithm for a
       particular blank node will always be the same. This is only true


### PR DESCRIPTION
… that referenced an empty list, rather than a list having more than one entry. Also, adds a brief introductory paragraph to the algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rch-rdc/pull/25.html" title="Last updated on Nov 4, 2022, 7:55 PM UTC (e4a9d24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rch-rdc/25/393048a...e4a9d24.html" title="Last updated on Nov 4, 2022, 7:55 PM UTC (e4a9d24)">Diff</a>